### PR TITLE
Improve logger shutdown and queue handling

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -49,7 +49,13 @@ object Logger : CoroutineScope {
         if (isReady) worker.collectFileInfo() else emptyMap()
 
     fun setDebug(enable: Boolean) { sDebug = enable }
-    fun close() { job.cancel() }
+
+    fun close() {
+        if (isReady) {
+            worker.close()
+        }
+        job.cancel()
+    }
 
     private fun ensureReady() {
         check(isReady) { "Please initialize MGLooger first" }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -7,6 +7,7 @@ import com.mgtv.logger.kt.i.ILoggerProtocol
 import com.mgtv.logger.kt.i.ILoggerStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.trySend
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -59,7 +60,13 @@ class LoggerActor(
      * 向 Actor 提交日志任务
      * @param task 日志任务
      */
-    fun offer(task: LogTask) { channel.offer(task) }
+    fun offer(task: LogTask): Boolean {
+        return channel.trySend(task).isSuccess
+    }
+
+    fun close() {
+        channel.close()
+    }
 
     /**
      * 收集日志文件信息


### PR DESCRIPTION
## Summary
- close `LoggerActor` channel when `Logger.close()` is called
- return result when enqueueing tasks to `LoggerActor`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e4071b60c8329a964e394f4988515