### PR TITLE
Fix MGLogger JNI naming

### DIFF
--- a/mglogger/src/main/cpp/jni/mglogger_jni.c
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.c
@@ -69,7 +69,7 @@ Java_com_mgtv_logger_CLoganProtocol_clogan_1debug(JNIEnv *env, jobject instance,
 
 
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1init(JNIEnv *env,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1init(JNIEnv *env,
                                                        jobject thiz,
                                                        jstring cache_path,
                                                        jstring dir_path,
@@ -91,7 +91,7 @@ Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1init(JNIEnv *env,
 }
 
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1open(JNIEnv *env,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1open(JNIEnv *env,
                                                        jobject thiz,
                                                        jstring file_name) {
     const char *file_name_ = (*env)->GetStringUTFChars(env, file_name, 0);
@@ -103,7 +103,7 @@ Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1open(JNIEnv *env,
 }
 
 JNIEXPORT void JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1debug(JNIEnv *env, jobject thiz,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1debug(JNIEnv *env, jobject thiz,
                                                         jboolean is_debug) {
     int i = 1;
     if (!is_debug) {
@@ -114,7 +114,7 @@ Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1debug(JNIEnv *env, jobject thi
 
 
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1write(JNIEnv *env,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1write(JNIEnv *env,
                                                         jobject thiz,
                                                         jint flag,
                                                         jstring log,
@@ -138,6 +138,6 @@ Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1write(JNIEnv *env,
 }
 
 JNIEXPORT void JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1flush(JNIEnv *env, jobject thiz) {
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1flush(JNIEnv *env, jobject thiz) {
     clogan_flush();
 }

--- a/mglogger/src/main/cpp/jni/mglogger_jni.h
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.h
@@ -48,30 +48,30 @@ Java_com_mgtv_logger_CLoganProtocol_clogan_1debug(JNIEnv *env, jobject thiz, jbo
  * JNI mglogger write interface
  */
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1init(JNIEnv *env, jobject thiz,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1init(JNIEnv *env, jobject thiz,
                                                        jstring cache_path, jstring dir_path,
                                                        jint max_file, jstring encrypt_key16,
                                                        jstring encrypt_iv16);
 
 
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1open(JNIEnv *env, jobject thiz,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1open(JNIEnv *env, jobject thiz,
                                                                jstring file_name);
 
 JNIEXPORT void JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1debug(JNIEnv *env, jobject thiz,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1debug(JNIEnv *env, jobject thiz,
                                                         jboolean is_debug);
 
 
 JNIEXPORT jint JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1write(JNIEnv *env, jobject thiz, jint flag,
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1write(JNIEnv *env, jobject thiz, jint flag,
                                                         jstring log, jlong local_time,
                                                         jstring thread_name, jlong thread_id,
                                                         jint is_main);
 
 
 JNIEXPORT void JNICALL
-Java_com_mgtv_logger_kt_log_MGLoogerJni_mglogger_1flush(JNIEnv *env, jobject thiz);
+Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1flush(JNIEnv *env, jobject thiz);
 
 #ifdef __cplusplus
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -52,7 +52,7 @@ object Logger : CoroutineScope {
     fun close() { job.cancel() }
 
     private fun ensureReady() {
-        check(isReady) { "Please initialize MGLooger first" }
+        check(isReady) { "Please initialize MGLogger first" }
     }
 
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -33,7 +33,7 @@ class LoggerActor(
     private val long24h = 24 * 60 * 60 * 1000L
 
     // protocol 策略
-    private val protocol: ILoggerProtocol = MGLoogerJni.also {
+    private val protocol: ILoggerProtocol = MGLoggerJni.also {
         it.setOnLoggerStatus(object : ILoggerStatus {
             override fun loggerStatus(cmd: String, code: Int) {
                 Logger.onListenerLogWriteStatus(cmd, code)

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -12,7 +12,7 @@ import java.util.Collections
  * Date： 2025/6/26
  * Time： 09:20
  */
-object MGLoogerJni : ILoggerProtocol {
+object MGLoggerJni : ILoggerProtocol {
 
     @Volatile
     private var isMGLoggerOk = false
@@ -28,9 +28,9 @@ object MGLoogerJni : ILoggerProtocol {
         }
     }
 
-    fun isMGLoogerSuccess(): Boolean = isMGLoggerOk
+    fun isMGLoggerSuccess(): Boolean = isMGLoggerOk
 
-    fun newInstance(): MGLoogerJni = this
+    fun newInstance(): MGLoggerJni = this
 
     private var isLoganInit = false
     private var isLoganOpen = false


### PR DESCRIPTION
## Summary
- rename `MGLoogerJni.kt` to `MGLoggerJni.kt`
- update JNI package references
- reference the new object name in Kotlin code
- fix initialization message

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e4023504883299a519a9e90ab89fd