### PR TITLE
fix: adapt LoggerActor to Kotlin 1.4

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -7,7 +7,6 @@ import com.mgtv.logger.kt.i.ILoggerProtocol
 import com.mgtv.logger.kt.i.ILoggerStatus
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.trySend
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -61,7 +60,7 @@ class LoggerActor(
      * @param task 日志任务
      */
     fun offer(task: LogTask): Boolean {
-        return channel.trySend(task).isSuccess
+        return channel.offer(task)
     }
 
     fun close() {


### PR DESCRIPTION
## Summary
- replace `trySend` with `offer` in LoggerActor for Kotlin 1.4.30

## Testing
- `./gradlew assemble` *(fails: Unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_685e508432908329b47822a9d6bddcf5