### PR TITLE
Integrate Koin module

### DIFF
--- a/mglogger/build.gradle
+++ b/mglogger/build.gradle
@@ -32,6 +32,13 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            jvmTarget = "1.8"
+            freeCompilerArgs += "-Xexplicit-api=strict"
+        }
+    }
+
     ndkVersion "16.1.4479499"
 }
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/di/LoggerModule.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/di/LoggerModule.kt
@@ -1,0 +1,17 @@
+package com.mgtv.logger.kt.di
+
+import com.mgtv.logger.kt.log.Logger
+import com.mgtv.logger.kt.log.LoggerConfig
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Provides Koin module for MGLogger.
+ */
+fun createLoggerModule(block: LoggerConfig.Builder.() -> Unit): Module {
+    val config = LoggerConfig.Builder().apply(block).build()
+    return module {
+        single { config }
+        single(createdAtStart = true) { Logger.apply { init(config) } }
+    }
+}

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -21,9 +21,13 @@ object Logger : CoroutineScope {
 
     val isReady: Boolean get() = this::worker.isInitialized
 
-    fun init(block: LoggerConfig.Builder.() -> Unit) {
-        cfg = LoggerConfig.Builder().apply(block).build()
+    fun init(config: LoggerConfig) {
+        cfg = config
         worker = LoggerActor(cfg, this)
+    }
+
+    fun init(block: LoggerConfig.Builder.() -> Unit) {
+        init(LoggerConfig.Builder().apply(block).build())
     }
 
     fun w(log: String, type: Int) {


### PR DESCRIPTION
## Summary
- add explicit API compiler flag for mglogger module
- expose Koin module helper to configure Logger
- allow initializing Logger with provided config

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_685e8c732e8483299b2d1146ada9610f