### PR TITLE
Add logger status listener API

### DIFF
--- a/mglogger/README.md
+++ b/mglogger/README.md
@@ -1,0 +1,17 @@
+# MGLogger
+
+This module provides a coroutine based log system.
+
+## Koin module example
+
+```kotlin
+val loggerModule = module {
+    single { Logger }
+}
+
+Logger.setStatusListener(object : ILoggerStatus {
+    override fun loggerStatus(cmd: String, code: Int) {
+        // handle status
+    }
+})
+```

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -50,6 +50,10 @@ object Logger : CoroutineScope {
 
     fun setDebug(enable: Boolean) { sDebug = enable }
 
+    fun setStatusListener(listener: ILoggerStatus): Unit {
+        statusListener = listener
+    }
+
     fun close() {
         if (isReady) {
             worker.close()


### PR DESCRIPTION
## Summary
- add `setStatusListener` API to `Logger`
- document usage in a new README with Koin example

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e9403470c8329a38e431640d480a5