### PR TITLE
Fix Logger worker lifecycle

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -17,9 +17,9 @@ object Logger : CoroutineScope {
     override val coroutineContext: CoroutineContext = Dispatchers.IO + job
 
     private lateinit var cfg: LoggerConfig
-    private lateinit var worker: LoggerActor
+    private var worker: LoggerActor? = null
 
-    val isReady: Boolean get() = this::worker.isInitialized
+    val isReady: Boolean get() = worker != null
 
     fun init(block: LoggerConfig.Builder.() -> Unit) {
         cfg = LoggerConfig.Builder().apply(block).build()
@@ -28,12 +28,12 @@ object Logger : CoroutineScope {
 
     fun w(log: String, type: Int) {
         ensureReady()
-        worker.offer(LogTask.Write(log, type))
+        worker!!.offer(LogTask.Write(log, type))
     }
 
     fun flush() {
         ensureReady()
-        worker.offer(LogTask.Flush)
+        worker!!.offer(LogTask.Flush)
     }
 
     fun send(
@@ -42,23 +42,24 @@ object Logger : CoroutineScope {
         callback: ((Int, ByteArray?) -> Unit)? = null
     ) {
         ensureReady()
-        dates.forEach { worker.offer(LogTask.Send(it, strategy, callback)) }
+        dates.forEach { worker!!.offer(LogTask.Send(it, strategy, callback)) }
     }
 
     fun getAllFilesInfo(): Map<String, Long> =
-        if (isReady) worker.collectFileInfo() else emptyMap()
+        worker?.collectFileInfo() ?: emptyMap()
 
     fun setDebug(enable: Boolean) { sDebug = enable }
 
     fun close() {
         if (isReady) {
-            worker.close()
+            worker?.close()
+            worker = null
         }
         job.cancel()
     }
 
     private fun ensureReady() {
-        check(isReady) { "Please initialize MGLogger first" }
+        check(isReady) { "MGLogger is not initialized or has been closed" }
     }
 
 


### PR DESCRIPTION
## Summary
- make Logger.worker nullable
- check worker != null when calling `isReady`
- null out worker after closing
- throw informative error if `w`, `flush`, or `send` invoked after `close`

## Testing
- `ktlint -F mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt` *(fails: command not found)*
- `./gradlew test` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685e9533461c832983271212bddcffc0