### PR TITLE
Fix LoggerActor send API

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -60,7 +60,7 @@ class LoggerActor(
      * @param task 日志任务
      */
     fun offer(task: LogTask): Boolean {
-        return channel.offer(task)
+        return channel.trySend(task).isSuccess
     }
 
     fun close() {


### PR DESCRIPTION
## Summary
- replace deprecated `channel.offer` with `trySend`

## Testing
- `./gradlew --version` *(fails: Unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685ea6a08dc88329a3a7738cd8f266e1