### PR TITLE
Add LoggerConfig builder setters

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerConfig.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerConfig.kt
@@ -25,6 +25,14 @@ data class LoggerConfig(
         var maxQueue: Int = 10_000
         var key16: String = "1234567890abcdef"
         var iv16: String = "abcdef1234567890"
+        fun setCachePath(path: String): Builder = apply { cachePath = path }
+        fun setLogDir(dir: String): Builder = apply { logDir = dir }
+        fun setKeepDays(days: Long): Builder = apply { keepDays = days }
+        fun setMaxFile(value: Long): Builder = apply { maxFile = value }
+        fun setMinSdCard(value: Long): Builder = apply { minSdCard = value }
+        fun setMaxQueue(value: Int): Builder = apply { maxQueue = value }
+        fun setKey16(key: String): Builder = apply { this.key16 = key }
+        fun setIv16(iv: String): Builder = apply { this.iv16 = iv }
         fun build() =
             LoggerConfig(cachePath, logDir, keepDays, maxFile, minSdCard, maxQueue, key16, iv16)
     }


### PR DESCRIPTION
## Summary
- enhance LoggerConfig builder with setter methods

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685eb08b4d1c832996a563ba9be4a82a