### PR TITLE
Expose MGLogger helper API

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
@@ -3,9 +3,11 @@ package com.mgtv.logger.kt.log
 import com.mgtv.logger.kt.di.createLoggerModule
 import com.mgtv.logger.kt.i.ILoggerStatus
 import org.koin.core.context.startKoin
+import com.mgtv.logger.kt.log.Logger
+import com.mgtv.logger.kt.log.SendLogStrategy
 
 /**
- * Description:
+ * Kotlin facade similar to [Logan] for easy access to [Logger].
  * Created by lantian
  * Date： 2025/6/27
  * Time： 22:38
@@ -22,11 +24,47 @@ object MGLogger {
                     {
                         putCachePath(config.cachePath)
                         putLogDir(config.logDir)
+                        putKeepDays(config.keepDays)
+                        putMaxFile(config.maxFile)
+                        putMinSdCard(config.minSdCard)
+                        putMaxQueue(config.maxQueue)
+                        putKey16(config.key16)
+                        putIv16(config.iv16)
                     },
                     loggerStatus = loggerStatus
                 )
             )
         }
+    }
+
+    fun w(log: String, type: Int) {
+        Logger.w(log, type)
+    }
+
+    fun flush() {
+        Logger.flush()
+    }
+
+    fun send(
+        dates: List<String>,
+        strategy: SendLogStrategy,
+        callback: ((Int, ByteArray?) -> Unit)? = null
+    ) {
+        Logger.send(dates, strategy, callback)
+    }
+
+    fun getAllFilesInfo(): Map<String, Long> = Logger.getAllFilesInfo()
+
+    fun setDebug(enable: Boolean) {
+        Logger.setDebug(enable)
+    }
+
+    fun setStatusListener(listener: ILoggerStatus?) {
+        Logger.setStatusListener(listener)
+    }
+
+    fun close() {
+        Logger.close()
     }
 
 }


### PR DESCRIPTION
## Summary
- expose convenience API on `MGLogger` similar to `Logan`
- delegate log actions to the `Logger` singleton

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ebbc2b17c8329bf50b98fb085ada3