### PR TITLE
Refactor send callback to interface

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
@@ -1,4 +1,6 @@
 package com.mgtv.logger.kt.log
+
+import com.mgtv.logger.kt.i.ISendLogCallback
 /**
  * Description:
  * Created by lantian
@@ -12,6 +14,6 @@ sealed class LogTask {
     data class Send(
         val date: String,
         val strategy: SendLogStrategy,
-        val callback: ((Int, ByteArray?) -> Unit)?
+        val callback: ISendLogCallback?
     ) : LogTask()
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -1,6 +1,7 @@
 package com.mgtv.logger.kt.log
 
 import com.mgtv.logger.kt.i.ILoggerStatus
+import com.mgtv.logger.kt.i.ISendLogCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -43,7 +44,7 @@ object Logger : CoroutineScope {
     fun send(
         dates: List<String>,
         strategy: SendLogStrategy,
-        callback: ((Int, ByteArray?) -> Unit)? = null
+        callback: ISendLogCallback? = null
     ) {
         ensureReady()
         dates.forEach { worker!!.offer(LogTask.Send(it, strategy, callback)) }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -5,6 +5,7 @@ import android.os.StatFs
 import com.mgtv.logger.java.Util
 import com.mgtv.logger.kt.i.ILoggerProtocol
 import com.mgtv.logger.kt.i.ILoggerStatus
+import com.mgtv.logger.kt.i.ISendLogCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
@@ -163,7 +164,7 @@ class LoggerActor(
         if (dateMillis == currentDay) protocol.logger_flush()
 
         val (status, body) = t.strategy.send(file)
-        t.callback?.invoke(status, body)
+        t.callback?.onLogSendCompleted(status, body)
     }
 
     /**

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
@@ -3,6 +3,7 @@ package com.mgtv.logger.kt.log
 import com.mgtv.logger.kt.di.createLoggerModule
 import com.mgtv.logger.kt.i.ILoggerStatus
 import org.koin.core.context.startKoin
+import com.mgtv.logger.kt.i.ISendLogCallback
 import com.mgtv.logger.kt.log.Logger
 import com.mgtv.logger.kt.log.SendLogStrategy
 
@@ -48,7 +49,7 @@ object MGLogger {
     fun send(
         dates: List<String>,
         strategy: SendLogStrategy,
-        callback: ((Int, ByteArray?) -> Unit)? = null
+        callback: ISendLogCallback? = null
     ) {
         Logger.send(dates, strategy, callback)
     }


### PR DESCRIPTION
## Summary
- replace function callback in `send` with `ISendLogCallback`
- update `Logger`, `LoggerActor`, and `MGLogger` to use the interface
- adjust `LogTask` data class for new callback type

## Testing
- `ktlint -F "mglogger/src/main/java/**/*.kt"` *(fails: command not found)*
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685ebf80b65c83298b02246a60d25747