### PR TITLE
fix(log): capture caller thread info

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
@@ -9,7 +9,13 @@ import com.mgtv.logger.kt.i.ISendLogCallback
  */
 
 internal sealed class LogTask {
-    internal data class Write(val log: String, val type: Int) : LogTask()
+    internal data class Write(
+        val log: String,
+        val type: Int,
+        val threadName: String,
+        val threadId: Long,
+        val isMainThread: Boolean
+    ) : LogTask()
     internal object Flush : LogTask()
     internal data class Send(
         val date: String,

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -1,5 +1,6 @@
 package com.mgtv.logger.kt.log
 
+import android.os.Looper
 import com.mgtv.logger.kt.i.ILoggerStatus
 import com.mgtv.logger.kt.i.ISendLogCallback
 import kotlinx.coroutines.CoroutineScope
@@ -33,7 +34,10 @@ public object Logger : CoroutineScope {
 
     public fun w(log: String, type: Int) {
         ensureReady()
-        worker!!.offer(LogTask.Write(log, type))
+        val threadName = Thread.currentThread().name
+        val threadId = Thread.currentThread().id
+        val isMainThread = Looper.getMainLooper() == Looper.myLooper()
+        worker!!.offer(LogTask.Write(log, type, threadName, threadId, isMainThread))
     }
 
     public fun flush() {

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -113,9 +113,9 @@ internal class LoggerActor(
             t.type,
             t.log,
             System.currentTimeMillis(),
-            Thread.currentThread().name,
-            Thread.currentThread().id,
-            Looper.getMainLooper() == Looper.myLooper()
+            t.threadName,
+            t.threadId,
+            t.isMainThread
         )
     }
 


### PR DESCRIPTION
## Summary
- keep original thread info when writing logs by capturing thread details

## Testing
- `./gradlew :mglogger:assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fc95a14b48329a4203957f58b51a2