### PR TITLE
Add crash handler

### DIFF
--- a/app/src/main/java/com/mgtv/mglogger/CrashHandler.java
+++ b/app/src/main/java/com/mgtv/mglogger/CrashHandler.java
@@ -1,0 +1,31 @@
+package com.mgtv.mglogger;
+
+import android.util.Log;
+
+import com.mgtv.logger.kt.log.MGLogger;
+
+/**
+ * Global crash handler that writes crash stack traces to MGLogger.
+ */
+public class CrashHandler implements Thread.UncaughtExceptionHandler {
+
+    private final Thread.UncaughtExceptionHandler defaultHandler;
+
+    private CrashHandler() {
+        this.defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
+    }
+
+    /** Install this crash handler as the default handler. */
+    public static void install() {
+        Thread.setDefaultUncaughtExceptionHandler(new CrashHandler());
+    }
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        MGLogger.w(Log.getStackTraceString(e), 3);
+        MGLogger.flush();
+        if (defaultHandler != null) {
+            defaultHandler.uncaughtException(t, e);
+        }
+    }
+}

--- a/app/src/main/java/com/mgtv/mglogger/MainActivity.java
+++ b/app/src/main/java/com/mgtv/mglogger/MainActivity.java
@@ -17,6 +17,8 @@ public class MainActivity extends AppCompatActivity {
         new Thread(() -> {
             MGLogger.w("MainActivity onCreate", 1);
         }).start();
+
+        throw new RuntimeException("Test Crash");
     }
 
 

--- a/app/src/main/java/com/mgtv/mglogger/MyApplication.java
+++ b/app/src/main/java/com/mgtv/mglogger/MyApplication.java
@@ -14,6 +14,8 @@ import com.mgtv.logger.kt.i.ILoggerStatus;
 import com.mgtv.logger.kt.log.LoggerConfig;
 import com.mgtv.logger.kt.log.MGLogger;
 
+import com.mgtv.mglogger.CrashHandler;
+
 import java.io.File;
 
 public class MyApplication extends Application {
@@ -29,6 +31,7 @@ public class MyApplication extends Application {
         path = Environment.getExternalStorageDirectory().getAbsolutePath()
                 + File.separator + "mgtv" + File.separator + FILE_NAME;
         initLogan();
+        CrashHandler.install();
     }
 
     private void initLogan() {


### PR DESCRIPTION
## Summary
- handle crashes by logging stacktraces
- install crash handler in application
- purposely crash in MainActivity for testing

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685fdb9091f483298997b3eb3ea72a35