### PR TITLE
feat(mglogger): add C++ AES util in mg module

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCE_FILES
         mglogger/zlib_util.c
         mglogger/json_util.c
         mglogger/aes_util.c
+        mglogger/mg/AesUtil.cpp
         mglogger/directory_util.c
         mglogger/base_util.c
         mglogger/console_util.c

--- a/mglogger/src/main/cpp/mglogger/mg/AesUtil.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/AesUtil.cpp
@@ -1,0 +1,25 @@
+#include "AesUtil.h"
+#include "mbedtls/aes.h"
+#include <cstring>
+
+AesUtil::AesUtil() {
+    std::memset(mKey, 0, sizeof(mKey));
+    std::memset(mIv, 0, sizeof(mIv));
+}
+
+void AesUtil::initKeyIv(const unsigned char *key, const unsigned char *iv) {
+    std::memcpy(mKey, key, 16);
+    std::memcpy(mIv, iv, 16);
+}
+
+void AesUtil::encrypt(const unsigned char *in, unsigned char *out, int length, unsigned char *iv) {
+    mbedtls_aes_context context;
+    mbedtls_aes_init(&context);
+    mbedtls_aes_setkey_enc(&context, mKey, 128);
+    mbedtls_aes_crypt_cbc(&context, MBEDTLS_AES_ENCRYPT, length, iv, in, out);
+    mbedtls_aes_free(&context);
+}
+
+void AesUtil::copyIv(unsigned char *out) const {
+    std::memcpy(out, mIv, 16);
+}

--- a/mglogger/src/main/cpp/mglogger/mg/AesUtil.h
+++ b/mglogger/src/main/cpp/mglogger/mg/AesUtil.h
@@ -1,0 +1,17 @@
+#ifndef MGLOGGER_MG_AESUTIL_H
+#define MGLOGGER_MG_AESUTIL_H
+
+#include <cstddef>
+
+class AesUtil {
+public:
+    AesUtil();
+    void initKeyIv(const unsigned char *key, const unsigned char *iv);
+    void encrypt(const unsigned char *in, unsigned char *out, int length, unsigned char *iv);
+    void copyIv(unsigned char *out) const;
+private:
+    unsigned char mKey[16];
+    unsigned char mIv[16];
+};
+
+#endif // MGLOGGER_MG_AESUTIL_H


### PR DESCRIPTION
## 变更概要
- 还原原有 C 版 `aes_util` 实现
- 在 `mg` 目录新增 `AesUtil` C++ 类封装 AES 加密逻辑
- 更新 CMake 配置编译新增的 `AesUtil.cpp`

## 关联 Issue/任务单
- 无

------
https://chatgpt.com/codex/tasks/task_e_686231a3cdec832999e76883c90acaf0