### PR TITLE
feat(mglogger): add C++ ZlibUtil

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCE_FILES
         mglogger/json_util.c
         mglogger/aes_util.c
         mglogger/mg/AesUtil.cpp
+        mglogger/mg/ZlibUtil.cpp
         mglogger/directory_util.c
         mglogger/base_util.c
         mglogger/console_util.c

--- a/mglogger/src/main/cpp/mglogger/mg/ZlibUtil.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/ZlibUtil.cpp
@@ -1,0 +1,124 @@
+#include "ZlibUtil.h"
+#include <cstring>
+
+namespace mg {
+
+ZlibUtil::ZlibUtil(std::shared_ptr<AesUtil> aes)
+        : mAes(std::move(aes)), mStream(new z_stream{}, [](z_stream *s) {
+    if (s) {
+        deflateEnd(s);
+        delete s;
+    }
+}) {
+    std::memset(mRemain, 0, sizeof(mRemain));
+}
+
+ZlibUtil::~ZlibUtil() = default;
+
+bool ZlibUtil::init() {
+    if (!mStream) {
+        mStream = std::unique_ptr<z_stream>(new z_stream{}, [](z_stream *s) {
+            if (s) {
+                deflateEnd(s);
+                delete s;
+            }
+        });
+    }
+    std::memset(mStream.get(), 0, sizeof(z_stream));
+    int ret = deflateInit2(mStream.get(), Z_BEST_COMPRESSION, Z_DEFLATED, 15 + 16,
+                           8, Z_DEFAULT_STRATEGY);
+    mReady = ret == Z_OK;
+    return mReady;
+}
+
+void ZlibUtil::handleData(const unsigned char *data, int length, std::vector<unsigned char> &out) {
+    int total = mRemainLen + length;
+    int block = (total / 16) * 16;
+    int remain = total % 16;
+    if (block > 0) {
+        std::vector<unsigned char> buffer(block);
+        unsigned char *ptr = buffer.data();
+        if (mRemainLen) {
+            std::memcpy(ptr, mRemain, mRemainLen);
+            ptr += mRemainLen;
+        }
+        int copy_len = block - mRemainLen;
+        if (copy_len > 0 && data) {
+            std::memcpy(ptr, data, copy_len);
+        }
+        unsigned char iv[16];
+        mAes->copyIv(iv);
+        std::vector<unsigned char> enc(block);
+        mAes->encrypt(buffer.data(), enc.data(), block, iv);
+        out.insert(out.end(), enc.begin(), enc.end());
+        if (length > copy_len) {
+            data += copy_len;
+        }
+    }
+    if (remain > 0) {
+        const unsigned char *remain_src = data + (block - mRemainLen);
+        std::memcpy(mRemain, remain_src, remain);
+    }
+    mRemainLen = remain;
+}
+
+std::vector<unsigned char> ZlibUtil::compress(const unsigned char *data, int length, int type) {
+    std::vector<unsigned char> encrypted;
+    if (!mAes) return encrypted;
+
+    if (mReady) {
+        mStream->avail_in = static_cast<uInt>(length);
+        mStream->next_in = const_cast<unsigned char *>(data);
+        unsigned char out[LOGAN_CHUNK];
+        int ret;
+        do {
+            mStream->avail_out = LOGAN_CHUNK;
+            mStream->next_out = out;
+            ret = deflate(mStream.get(), type);
+            if (ret == Z_STREAM_ERROR) {
+                mReady = false;
+                break;
+            }
+            unsigned have = LOGAN_CHUNK - mStream->avail_out;
+            if (have > 0) {
+                handleData(out, have, encrypted);
+            }
+        } while (mStream->avail_out == 0);
+    } else if (length > 0) {
+        handleData(data, length, encrypted);
+    }
+    return encrypted;
+}
+
+std::vector<unsigned char> ZlibUtil::endCompress() {
+    std::vector<unsigned char> out;
+    if (mReady) {
+        std::vector<unsigned char> tmp = compress(nullptr, 0, Z_FINISH);
+        out.insert(out.end(), tmp.begin(), tmp.end());
+        reset();
+    }
+    unsigned char padding[16];
+    int val = 16 - mRemainLen;
+    std::memset(padding, val, 16);
+    if (mRemainLen > 0) {
+        std::memcpy(padding, mRemain, mRemainLen);
+    }
+    unsigned char iv[16];
+    mAes->copyIv(iv);
+    std::vector<unsigned char> enc(16);
+    mAes->encrypt(padding, enc.data(), 16, iv);
+    out.insert(out.end(), enc.begin(), enc.end());
+    mRemainLen = 0;
+    return out;
+}
+
+void ZlibUtil::reset() {
+    if (mStream) {
+        deflateEnd(mStream.get());
+    }
+    mReady = false;
+    mRemainLen = 0;
+}
+
+} // namespace mg
+

--- a/mglogger/src/main/cpp/mglogger/mg/ZlibUtil.h
+++ b/mglogger/src/main/cpp/mglogger/mg/ZlibUtil.h
@@ -1,0 +1,33 @@
+#ifndef MGLOGGER_MG_ZLIBUTIL_H
+#define MGLOGGER_MG_ZLIBUTIL_H
+
+#include <memory>
+#include <vector>
+#include <zlib.h>
+#include "AesUtil.h"
+
+namespace mg {
+
+class ZlibUtil {
+public:
+    explicit ZlibUtil(std::shared_ptr<AesUtil> aes);
+    ~ZlibUtil();
+
+    bool init();
+    std::vector<unsigned char> compress(const unsigned char *data, int length, int type);
+    std::vector<unsigned char> endCompress();
+    void reset();
+
+private:
+    void handleData(const unsigned char *data, int length, std::vector<unsigned char> &out);
+
+    std::shared_ptr<AesUtil> mAes;
+    std::unique_ptr<z_stream> mStream;
+    bool mReady{false};
+    unsigned char mRemain[16]{0};
+    int mRemainLen{0};
+};
+
+} // namespace mg
+
+#endif // MGLOGGER_MG_ZLIBUTIL_H


### PR DESCRIPTION
## Summary
- implement `ZlibUtil` in `mg` directory using C++
- integrate AES encryption via existing `AesUtil`
- update CMakeLists to compile the new file

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68624be33bbc8329bb6563863fbe438d