### PR TITLE
feat(logger): add max line support for syslog

### DIFF
--- a/app/src/main/java/com/mgtv/mglogger/CrashHandler.java
+++ b/app/src/main/java/com/mgtv/mglogger/CrashHandler.java
@@ -23,6 +23,10 @@ public class CrashHandler implements Thread.UncaughtExceptionHandler {
     @Override
     public void uncaughtException(Thread t, Throwable e) {
         MGLogger.w(Log.getStackTraceString(e), 3);
+        String systemLog = MGLogger.getSystemLogs(200);
+        if (!systemLog.isEmpty()) {
+            MGLogger.w(systemLog, 3);
+        }
         MGLogger.flush();
         if (defaultHandler != null) {
             defaultHandler.uncaughtException(t, e);

--- a/mglogger/src/main/cpp/jni/NativeLogReaderJni.cpp
+++ b/mglogger/src/main/cpp/jni/NativeLogReaderJni.cpp
@@ -7,7 +7,6 @@
 
 
 #include <jni.h>
-#include <thread>
 #include <string>
 #include <sstream>
 #include <stdio.h>
@@ -15,8 +14,9 @@
 
 static std::string g_system_log;
 
-static void read_system_log() {
-    FILE *pipe = popen("logcat -d", "r");
+static void read_system_log(int max_lines) {
+    std::string cmd = "logcat -d -t " + std::to_string(max_lines);
+    FILE *pipe = popen(cmd.c_str(), "r");
     if (pipe == nullptr) {
         return;
     }
@@ -32,9 +32,9 @@ static void read_system_log() {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeGetSystemLog(
         JNIEnv *env,
-        jobject /* thiz */) {
+        jobject /* thiz */,
+        jint max_lines) {
     g_system_log.clear();
-    std::thread t(read_system_log);
-    t.join();
+    read_system_log(max_lines);
     return env->NewStringUTF(g_system_log.c_str());
 }

--- a/mglogger/src/main/cpp/jni/NativeLogReaderJni.h
+++ b/mglogger/src/main/cpp/jni/NativeLogReaderJni.h
@@ -9,7 +9,8 @@ extern "C" {
 
 JNIEXPORT jstring JNICALL
 Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeGetSystemLog(JNIEnv *env,
-                                                           jobject thiz);
+                                                           jobject thiz,
+                                                           jint max_lines);
 
 #ifdef __cplusplus
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
@@ -1,6 +1,7 @@
 package com.mgtv.logger.kt.log
 
 import com.mgtv.logger.kt.i.ISendLogCallback
+import kotlinx.coroutines.CompletableDeferred
 /**
  * Description:
  * Created by lantian
@@ -21,5 +22,9 @@ internal sealed class LogTask {
         val date: String,
         val strategy: SendLogStrategy,
         val callback: ISendLogCallback?
+    ) : LogTask()
+    internal data class GetSysLog(
+        val maxLines: Int,
+        val result: CompletableDeferred<String>
     ) : LogTask()
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -6,6 +6,8 @@ import com.mgtv.logger.kt.i.ISendLogCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -38,6 +40,13 @@ public object Logger : CoroutineScope {
         val threadId = Thread.currentThread().id
         val isMainThread = Looper.getMainLooper() == Looper.myLooper()
         worker!!.offer(LogTask.Write(log, type, threadName, threadId, isMainThread))
+    }
+
+    public fun getSystemLogs(maxLines: Int = 200): String {
+        ensureReady()
+        val result = CompletableDeferred<String>()
+        worker!!.offer(LogTask.GetSysLog(maxLines, result))
+        return runBlocking { result.await() }
     }
 
     public fun flush() {

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -90,6 +90,8 @@ internal class LoggerActor(
             is LogTask.Write -> write(task)
             is LogTask.Flush -> protocol.logger_flush()
             is LogTask.Send -> send(task)
+            is LogTask.GetSysLog ->
+                task.result.complete(MGLoggerJni.getSystemLog(task.maxLines))
         }
     }
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
@@ -44,6 +44,10 @@ public object MGLogger {
     }
 
     @JvmStatic
+    public fun getSystemLogs(maxLines: Int = 200): String =
+        Logger.getSystemLogs(maxLines)
+
+    @JvmStatic
     public fun flush() {
         Logger.flush()
     }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -63,10 +63,10 @@ public object MGLoggerJni : ILoggerProtocol {
 
     private external fun mglogger_flush()
 
-    private external fun nativeGetSystemLog(): String
+    private external fun nativeGetSystemLog(maxLines: Int): String
 
-    public fun getSystemLog(): String = try {
-        nativeGetSystemLog()
+    public fun getSystemLog(maxLines: Int): String = try {
+        nativeGetSystemLog(maxLines)
     } catch (e: UnsatisfiedLinkError) {
         e.printStackTrace()
         ""


### PR DESCRIPTION
## 变更概要
- pass log line limit through `LogTask.GetSysLog`
- forward max line argument to `MGLoggerJni.getSystemLog`
- extend native system log JNI to accept a line count
- remove redundant threading in native log reader

## 关联 Issue/任务单
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68627783dd288329bacbaa0f7d1c2d3b