### PR TITLE
Fix NDK build error

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -218,6 +218,7 @@ add_library(mglogger SHARED
     ${SOURCE_FILES}
     jni/mglogger_jni.c
     jni/NativeLogReaderJni.cpp
+    compat/quick_exit_stub.cpp
 )
 target_link_libraries(mglogger 
     ${log-lib} 

--- a/mglogger/src/main/cpp/compat/quick_exit_stub.cpp
+++ b/mglogger/src/main/cpp/compat/quick_exit_stub.cpp
@@ -1,0 +1,11 @@
+#include <android/api-level.h>
+#include <stdlib.h>
+#if __ANDROID_API__ < 21
+extern "C" int at_quick_exit(void (*func)(void)) {
+    return atexit(func);
+}
+
+extern "C" void quick_exit(int status) {
+    exit(status);
+}
+#endif


### PR DESCRIPTION
## Summary
- provide quick_exit/at_quick_exit stubs for API < 21
- register the stub in CMake

## Testing
- `./gradlew :mglogger:tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686297224f6883299f032cae487a79b6