### PR TITLE
feat: replace native system log reader

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -217,7 +217,6 @@ endif ()
 add_library(mglogger SHARED
         ${SOURCE_FILES}
         jni/mglogger_jni.c
-        jni/NativeLogReaderJni.cpp
 )
 target_link_libraries(mglogger
         ${log-lib}

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -63,14 +63,22 @@ public object MGLoggerJni : ILoggerProtocol {
 
     private external fun mglogger_flush()
 
-    private external fun nativeGetSystemLog(maxLines: Int): String
-
-    public fun getSystemLog(maxLines: Int): String = try {
-        nativeGetSystemLog(maxLines)
-    } catch (e: UnsatisfiedLinkError) {
+    private fun readSystemLog(maxLines: Int): String = try {
+        val process = ProcessBuilder(
+            "logcat",
+            "-d",
+            "-t",
+            maxLines.toString()
+        )
+            .redirectErrorStream(true)
+            .start()
+        process.inputStream.bufferedReader().use { it.readText() }
+    } catch (e: Exception) {
         e.printStackTrace()
         ""
     }
+
+    public fun getSystemLog(maxLines: Int): String = readSystemLog(maxLines)
 
     // ----------------------------
     // LoganProtocolHandler impl


### PR DESCRIPTION
## Summary
- reimplement system log reader in Kotlin
- remove `NativeLogReaderJni.cpp` from CMake build

## Testing
- `./gradlew lint` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6862abea09388329b6081ecc9afce6cf