### PR TITLE
Add logcat collector

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -217,6 +217,7 @@ endif ()
 add_library(mglogger SHARED
         ${SOURCE_FILES}
         jni/mglogger_jni.c
+        jni/LogcatCollector.cpp
 )
 target_link_libraries(mglogger
         ${log-lib}

--- a/mglogger/src/main/cpp/jni/LogcatCollector.cpp
+++ b/mglogger/src/main/cpp/jni/LogcatCollector.cpp
@@ -1,0 +1,111 @@
+#include "LogcatCollector.h"
+#include "clogan_core.h"
+#include "base_util.h"
+#include <pthread.h>
+#include <vector>
+#include <string>
+#include <atomic>
+#include <unistd.h>
+#include <cstdio>
+#include <cstring>
+
+static pthread_t g_logcat_thread;
+static pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+static std::atomic<int> g_running(0);
+static std::vector<std::string> g_blacklist;
+static JavaVM *g_vm = nullptr;
+static jobject g_obj = nullptr;
+
+static bool is_blacklisted(const char *tag) {
+    if (!tag) return false;
+    for (const auto &item : g_blacklist) {
+        if (item == tag) return true;
+    }
+    return false;
+}
+
+static std::string extract_tag(const char *line) {
+    const char *colon = strchr(line, ':');
+    if (!colon) return "";
+    const char *p = colon;
+    while (p > line && *p != ' ') {
+        --p;
+    }
+    if (*p == ' ') ++p;
+    return std::string(p, colon - p);
+}
+
+static void callback_fail() {
+    if (!g_vm || !g_obj) return;
+    JNIEnv *env = nullptr;
+    if (g_vm->AttachCurrentThread(&env, nullptr) != JNI_OK) return;
+    jclass cls = env->GetObjectClass(g_obj);
+    if (cls) {
+        jmethodID mid = env->GetMethodID(cls, "onLogcatCollectorFail", "()V");
+        if (mid) env->CallVoidMethod(g_obj, mid);
+        env->DeleteLocalRef(cls);
+    }
+    g_vm->DetachCurrentThread();
+}
+
+static void *logcat_loop(void *) {
+    int retry = 0;
+    while (g_running.load()) {
+        FILE *pipe = popen("logcat -v threadtime", "r");
+        if (!pipe) {
+            if (++retry >= 3) {
+                callback_fail();
+                g_running.store(0);
+                break;
+            }
+            sleep(1);
+            continue;
+        }
+        retry = 0;
+        char line[1024];
+        while (g_running.load() && fgets(line, sizeof(line), pipe)) {
+            std::string tag = extract_tag(line);
+            if (is_blacklisted(tag.c_str())) continue;
+            clogan_write(0, line, get_system_current_clogan(), (char *)"logcat", 0, 0);
+        }
+        pclose(pipe);
+    }
+    if (g_obj) {
+        JNIEnv *env = nullptr;
+        if (g_vm && g_vm->AttachCurrentThread(&env, nullptr) == JNI_OK) {
+            env->DeleteGlobalRef(g_obj);
+            g_vm->DetachCurrentThread();
+        }
+        g_obj = nullptr;
+    }
+    return nullptr;
+}
+
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
+                                                                   jobject thiz,
+                                                                   jobjectArray blacklist) {
+    pthread_mutex_lock(&g_mutex);
+    if (g_running.load()) {
+        pthread_mutex_unlock(&g_mutex);
+        return;
+    }
+
+    g_blacklist.clear();
+    if (blacklist) {
+        jsize len = env->GetArrayLength(blacklist);
+        for (jsize i = 0; i < len; ++i) {
+            jstring item = (jstring) env->GetObjectArrayElement(blacklist, i);
+            const char *str = env->GetStringUTFChars(item, 0);
+            g_blacklist.push_back(str ? str : "");
+            env->ReleaseStringUTFChars(item, str);
+            env->DeleteLocalRef(item);
+        }
+    }
+
+    env->GetJavaVM(&g_vm);
+    g_obj = env->NewGlobalRef(thiz);
+    g_running.store(1);
+    pthread_create(&g_logcat_thread, nullptr, logcat_loop, nullptr);
+    pthread_mutex_unlock(&g_mutex);
+}

--- a/mglogger/src/main/cpp/jni/LogcatCollector.h
+++ b/mglogger/src/main/cpp/jni/LogcatCollector.h
@@ -1,0 +1,19 @@
+#ifndef MGLOGGER_LOGCAT_COLLECTOR_H
+#define MGLOGGER_LOGCAT_COLLECTOR_H
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
+                                                                   jobject thiz,
+                                                                   jobjectArray blacklist);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //MGLOGGER_LOGCAT_COLLECTOR_H

--- a/mglogger/src/main/java/com/mgtv/logger/kt/common/MGLoggerStatus.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/common/MGLoggerStatus.kt
@@ -33,4 +33,7 @@ public object MGLoggerStatus {
     public val MGLOGGER_WRITE_FAIL_JNI: Int = -4060 //jni找不到对应C函数
     public const val MGLOGGER_LOAD_SO: String = "logan_loadso" //Logan装载So;
     public val MGLOGGER_LOAD_SO_FAIL: Int = -5020 //加载的SO失败
+
+    public const val MGLOGGER_LOGCAT_COLLECTOR_STATUS: String = "logcat_collector"
+    public val MGLOGGER_LOGCAT_COLLECTOR_FAIL: Int = -6010
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -62,23 +62,15 @@ public object MGLoggerJni : ILoggerProtocol {
     ): Int
 
     private external fun mglogger_flush()
+    private external fun nativeStartLogcatCollector(blackList: Array<String>)
 
-    private fun readSystemLog(maxLines: Int): String = try {
-        val process = ProcessBuilder(
-            "logcat",
-            "-d",
-            "-t",
-            maxLines.toString()
-        )
-            .redirectErrorStream(true)
-            .start()
-        process.inputStream.bufferedReader().use { it.readText() }
-    } catch (e: Exception) {
-        e.printStackTrace()
-        ""
+    public fun startLogcatCollector(blackList: Array<String>) {
+        try {
+            nativeStartLogcatCollector(blackList)
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+        }
     }
-
-    public fun getSystemLog(maxLines: Int): String = readSystemLog(maxLines)
 
     // ----------------------------
     // LoganProtocolHandler impl
@@ -184,5 +176,12 @@ public object MGLoggerJni : ILoggerProtocol {
             }
             loggerStatus?.loggerStatus(cmd, code)
         }
+    }
+
+    internal fun onLogcatCollectorFail() {
+        loggerStatusCode(
+            MGLoggerStatus.MGLOGGER_LOGCAT_COLLECTOR_STATUS,
+            MGLoggerStatus.MGLOGGER_LOGCAT_COLLECTOR_FAIL
+        )
     }
 }


### PR DESCRIPTION
## Summary
- implement background logcat collector in C++ with blacklist filtering
- expose start API and failure callback via JNI
- add logcat status constants

## Testing
- `./gradlew ktlintFormat` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2eac870832997f3267fdbf7e4b0