### PR TITLE
Add Logreader for system log capture

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SOURCE_FILES
         mglogger/base_util.c
         mglogger/console_util.c
         mglogger/main.c
+        mglogger/mg/Logreader.cpp
 )
 
 # MbedTLS crypto source files

--- a/mglogger/src/main/cpp/jni/mglogger_jni.h
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.h
@@ -73,6 +73,11 @@ Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1write(JNIEnv *env, jobject thi
 JNIEXPORT void JNICALL
 Java_com_mgtv_logger_kt_log_MGLoggerJni_mglogger_1flush(JNIEnv *env, jobject thiz);
 
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
+                                                                   jobject thiz,
+                                                                   jobjectArray blacklist);
+
 
 #ifdef __cplusplus
 }

--- a/mglogger/src/main/cpp/mglogger/mg/Logreader.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/Logreader.cpp
@@ -1,0 +1,100 @@
+#include "Logreader.h"
+#include <vector>
+#include <string>
+#include <pthread.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <cstdio>
+#include <cstring>
+#include <time.h>
+#include "clogan_core.h"
+
+static bool s_running = false;
+static pid_t s_child_pid = -1;
+static pthread_t s_thread;
+static std::vector<std::string> s_blacklist;
+static logreader_fail_callback s_fail_cb = nullptr;
+
+static bool filter_line(const char *line) {
+    for (const auto &w : s_blacklist) {
+        if (!w.empty() && strstr(line, w.c_str()) != nullptr) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void *reader_thread(void *) {
+    int pipe_fd[2];
+    if (pipe(pipe_fd) == -1) {
+        if (s_fail_cb) s_fail_cb();
+        s_running = false;
+        return nullptr;
+    }
+    s_child_pid = fork();
+    if (s_child_pid < 0) {
+        if (s_fail_cb) s_fail_cb();
+        close(pipe_fd[0]);
+        close(pipe_fd[1]);
+        s_running = false;
+        return nullptr;
+    } else if (s_child_pid == 0) {
+        // child process
+        close(pipe_fd[0]);
+        dup2(pipe_fd[1], STDOUT_FILENO);
+        dup2(pipe_fd[1], STDERR_FILENO);
+        close(pipe_fd[1]);
+        execlp("logcat", "logcat", "-v", "time", nullptr);
+        _exit(1);
+    }
+    // parent
+    close(pipe_fd[1]);
+    FILE *fp = fdopen(pipe_fd[0], "r");
+    if (!fp) {
+        if (s_fail_cb) s_fail_cb();
+        close(pipe_fd[0]);
+        s_running = false;
+        return nullptr;
+    }
+    char buffer[1024];
+    while (s_running && fgets(buffer, sizeof(buffer), fp)) {
+        if (!filter_line(buffer)) {
+            long long ts = (long long)time(nullptr) * 1000LL;
+            clogan_write(0, buffer, ts, (char *)"logcat", (long long)gettid(), 0);
+        }
+    }
+    fclose(fp);
+    waitpid(s_child_pid, nullptr, 0);
+    s_child_pid = -1;
+    s_running = false;
+    return nullptr;
+}
+
+int start_logreader(const char **blacklist, int count, logreader_fail_callback cb) {
+    if (s_running) return 0;
+    s_running = true;
+    s_fail_cb = cb;
+    s_blacklist.clear();
+    for (int i = 0; i < count; ++i) {
+        if (blacklist[i]) {
+            s_blacklist.emplace_back(blacklist[i]);
+        }
+    }
+    if (pthread_create(&s_thread, nullptr, reader_thread, nullptr) != 0) {
+        s_running = false;
+        if (s_fail_cb) s_fail_cb();
+        return -1;
+    }
+    pthread_detach(s_thread);
+    return 0;
+}
+
+void stop_logreader() {
+    if (!s_running) return;
+    s_running = false;
+    if (s_child_pid > 0) {
+        kill(s_child_pid, SIGTERM);
+        waitpid(s_child_pid, nullptr, 0);
+        s_child_pid = -1;
+    }
+}

--- a/mglogger/src/main/cpp/mglogger/mg/Logreader.h
+++ b/mglogger/src/main/cpp/mglogger/mg/Logreader.h
@@ -1,0 +1,17 @@
+#ifndef MGLOGGER_LOGREADER_H
+#define MGLOGGER_LOGREADER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*logreader_fail_callback)();
+
+int start_logreader(const char **blacklist, int count, logreader_fail_callback cb);
+void stop_logreader();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //MGLOGGER_LOGREADER_H

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -41,6 +41,7 @@ internal class LoggerActor(
         })
         it.logger_init(cfg.cachePath, cfg.logDir, cfg.maxFile.toInt(), cfg.key16, cfg.iv16)
         it.logger_debug(Logger.sDebug)
+        it.startLogcatCollector(cfg.logcatBlackList.toTypedArray())
     }
 
     private val isSdWritable = AtomicBoolean(true)

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerConfig.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerConfig.kt
@@ -14,7 +14,8 @@ public data class LoggerConfig(
     public val minSdCard: Long,
     public val maxQueue: Int,
     public val key16: String,
-    public val iv16: String
+    public val iv16: String,
+    public val logcatBlackList: List<String> = emptyList()
 ) {
     public class Builder {
         public var cachePath: String = ""
@@ -25,6 +26,7 @@ public data class LoggerConfig(
         public var maxQueue: Int = 10_000
         public var key16: String = "1234567890abcdef"
         public var iv16: String = "abcdef1234567890"
+        public var logcatBlackList: List<String> = emptyList()
         public fun putCachePath(path: String): Builder = apply { cachePath = path }
         public fun putLogDir(dir: String): Builder = apply { logDir = dir }
         public fun putKeepDays(days: Long): Builder = apply { keepDays = days }
@@ -33,7 +35,20 @@ public data class LoggerConfig(
         public fun putMaxQueue(value: Int): Builder = apply { maxQueue = value }
         public fun putKey16(key: String): Builder = apply { this.key16 = key }
         public fun putIv16(iv: String): Builder = apply { this.iv16 = iv }
+        public fun putLogcatBlackList(list: List<String>): Builder = apply {
+            this.logcatBlackList = list
+        }
         public fun build(): LoggerConfig =
-            LoggerConfig(cachePath, logDir, keepDays, maxFile, minSdCard, maxQueue, key16, iv16)
+            LoggerConfig(
+                cachePath,
+                logDir,
+                keepDays,
+                maxFile,
+                minSdCard,
+                maxQueue,
+                key16,
+                iv16,
+                logcatBlackList
+            )
     }
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -62,15 +62,15 @@ public object MGLoggerJni : ILoggerProtocol {
     ): Int
 
     private external fun mglogger_flush()
-//    private external fun nativeStartLogcatCollector(blackList: Array<String>)
+    private external fun nativeStartLogcatCollector(blackList: Array<String>)
 
-//    public fun startLogcatCollector(blackList: Array<String>) {
-//        try {
-//            nativeStartLogcatCollector(blackList)
-//        } catch (e: UnsatisfiedLinkError) {
-//            e.printStackTrace()
-//        }
-//    }
+    public fun startLogcatCollector(blackList: Array<String>) {
+        try {
+            nativeStartLogcatCollector(blackList)
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+        }
+    }
 
     // ----------------------------
     // LoganProtocolHandler impl


### PR DESCRIPTION
## Summary
- implement Logreader in C++ to fork `logcat` and write logs via `clogan_write`
- expose native start function through JNI and Kotlin API
- allow configuring logcat blacklist in `LoggerConfig`
- start logcat collector when `LoggerActor` is initialized

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686635746d808329b41c1b7cc41f5720