### PR TITLE
Allow logdr collector without output path

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/Logreader.h
+++ b/mglogger/src/main/cpp/mglogger/mg/Logreader.h
@@ -11,7 +11,7 @@ int start_logreader(const char **blacklist, int count, logreader_fail_callback c
 void stop_logreader();
 
 // Start collecting logs directly from logd via logdr socket.
-// If output_path is nullptr, logs are printed to stdout.
+// If output_path is nullptr, logs are only written through CLogan.
 // If pid_filter > 0, only logs from this pid are forwarded.
 int start_logdr_reader(const char *output_path, int pid_filter, logreader_fail_callback cb);
 void stop_logdr_reader();


### PR DESCRIPTION
## Summary
- avoid writing logdr output to stdout when no file path is provided
- update header comment accordingly

## Testing
- `./gradlew test --dry-run` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686749974e1c8329a0a81d6001ac5d12