### PR TITLE
Add clogan-based log hook

### DIFF
--- a/mglogger/src/main/cpp/jni/mglogger_jni.c
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.c
@@ -211,3 +211,8 @@ Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
         free(list);
     }
 }
+
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeHookLogs(JNIEnv *env, jobject thiz) {
+    hook_log();
+}

--- a/mglogger/src/main/cpp/jni/mglogger_jni.h
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.h
@@ -78,6 +78,9 @@ Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
                                                                    jobject thiz,
                                                                    jobjectArray blacklist);
 
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeHookLogs(JNIEnv *env, jobject thiz);
+
 
 #ifdef __cplusplus
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LogTask.kt
@@ -24,4 +24,5 @@ internal sealed class LogTask {
         val callback: ISendLogCallback?
     ) : LogTask()
     internal object GetSysLog : LogTask()
+    internal object HookLogs : LogTask()
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/Logger.kt
@@ -47,6 +47,11 @@ public object Logger : CoroutineScope {
         worker!!.offer(LogTask.GetSysLog)
     }
 
+    public fun hookLogs() {
+        ensureReady()
+        worker!!.offer(LogTask.HookLogs)
+    }
+
     public fun flush() {
         ensureReady()
         worker!!.offer(LogTask.Flush)

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -90,6 +90,7 @@ internal class LoggerActor(
             is LogTask.Flush -> protocol.logger_flush()
             is LogTask.Send -> send(task)
             is LogTask.GetSysLog -> MGLoggerJni.startLogcatCollector(cfg.logcatBlackList.toTypedArray())
+            is LogTask.HookLogs -> MGLoggerJni.hookLogs()
         }
     }
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
@@ -47,6 +47,9 @@ public object MGLogger {
     public fun getSystemLogs() = Logger.getSystemLogs()
 
     @JvmStatic
+    public fun hookLogs() { Logger.hookLogs() }
+
+    @JvmStatic
     public fun flush() {
         Logger.flush()
     }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -63,10 +63,19 @@ public object MGLoggerJni : ILoggerProtocol {
 
     private external fun mglogger_flush()
     private external fun nativeStartLogcatCollector(blackList: Array<String>)
+    private external fun nativeHookLogs()
 
     public fun startLogcatCollector(blackList: Array<String>) {
         try {
             nativeStartLogcatCollector(blackList)
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+        }
+    }
+
+    public fun hookLogs() {
+        try {
+            nativeHookLogs()
         } catch (e: UnsatisfiedLinkError) {
             e.printStackTrace()
         }


### PR DESCRIPTION
## Summary
- optimize HookLoglib to write intercepted logs with `clogan_write`
- expose log hooking via new JNI function
- support HookLogs task and Kotlin wrapper methods

## Testing
- `./gradlew :mglogger:assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew tasks` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686808dae9c083298e2c614804f7ca09