### PR TITLE
Fix xhook logging bug

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/HookLoglib.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/HookLoglib.cpp
@@ -45,7 +45,7 @@ static int hook_log_print(int prio, const char* tag, const char* fmt, ...) {
     if (orig_log_vprint) {
         result = orig_log_vprint(prio, tag, fmt, args_copy);
     } else if (orig_log_print) {
-        result = orig_log_print(prio, tag, fmt, args_copy);
+        result = orig_log_print(prio, tag, "%s", msgBuf);
     }
     va_end(args_copy);
     return result;


### PR DESCRIPTION
## Summary
- correct vararg handling in the xhook logging wrapper

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b6fca44d48329bed6e9b74dcf0639