### PR TITLE
Add loggerlist-based log collection

### DIFF
--- a/mglogger/src/main/cpp/jni/mglogger_jni.c
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.c
@@ -201,3 +201,9 @@ JNIEXPORT void JNICALL
 Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeHookLogs(JNIEnv *env, jobject thiz) {
     hook_log();
 }
+
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeCollectLogByLoggerList(JNIEnv *env,
+                                                                     jobject thiz) {
+    collect_log_by_loggerlist();
+}

--- a/mglogger/src/main/cpp/jni/mglogger_jni.h
+++ b/mglogger/src/main/cpp/jni/mglogger_jni.h
@@ -81,6 +81,10 @@ Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeStartLogcatCollector(JNIEnv *env,
 JNIEXPORT void JNICALL
 Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeHookLogs(JNIEnv *env, jobject thiz);
 
+JNIEXPORT void JNICALL
+Java_com_mgtv_logger_kt_log_MGLoggerJni_nativeCollectLogByLoggerList(JNIEnv *env,
+                                                                     jobject thiz);
+
 
 #ifdef __cplusplus
 }

--- a/mglogger/src/main/cpp/mglogger/mg/Logreader.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/Logreader.cpp
@@ -9,6 +9,8 @@
 #include <cstring>
 #include <ctime>
 #include <android/log.h>
+#include <log/log_read.h>
+#include <log/logger.h>
 #include "clogan_core.h"
 
 static bool s_running = false;
@@ -125,4 +127,22 @@ void stop_logreader() {
         waitpid(s_child_pid, nullptr, 0);
         s_child_pid = -1;
     }
+}
+
+void collect_log_by_loggerlist() {
+    __android_log_print(ANDROID_LOG_DEBUG, "Logreader", "collect_log_by_loggerlist");
+    struct logger_list *logger_list = android_logger_list_open(LOG_ID_MAIN, ANDROID_LOG_RDONLY, 0, getpid());
+    if (!logger_list) {
+        __android_log_print(ANDROID_LOG_ERROR, "Logreader", "android_logger_list_open failed");
+        return;
+    }
+    android_logger_open(logger_list, LOG_ID_SYSTEM);
+
+    struct log_msg log_entry;
+    while (android_logger_list_read(logger_list, &log_entry) > 0) {
+        if (log_entry.entry.pid != getpid()) continue;
+        long long ts = (long long)time(nullptr) * 1000LL;
+        clogan_write(0, log_entry.msg, ts, (char *)"logcat", (long long)gettid(), 0);
+    }
+    android_logger_list_close(logger_list);
 }

--- a/mglogger/src/main/cpp/mglogger/mg/Logreader.h
+++ b/mglogger/src/main/cpp/mglogger/mg/Logreader.h
@@ -10,6 +10,9 @@ typedef void (*logreader_fail_callback)();
 int start_logreader(const char **blacklist, int count, logreader_fail_callback cb);
 void stop_logreader();
 
+// Collect logs from log buffers using android_logger_list_read
+void collect_log_by_loggerlist();
+
 void hook_log();
 
 #ifdef __cplusplus

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -94,10 +94,10 @@ internal class LoggerActor(
             is LogTask.Flush -> protocol.logger_flush()
             is LogTask.Send -> send(task)
             is LogTask.GetSysLog -> {
-                if (task.mode == 1) {
-                    MGLoggerJni.startLogcatCollector(cfg.logcatBlackList.toTypedArray())
-                } else {
-                    collectProcessLogcat()
+                when (task.mode) {
+                    1 -> MGLoggerJni.startLogcatCollector(cfg.logcatBlackList.toTypedArray())
+                    2 -> collectProcessLogcat()
+                    else -> MGLoggerJni.collectLogByLoggerList()
                 }
             }
             is LogTask.HookLogs -> MGLoggerJni.hookLogs()

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -65,6 +65,7 @@ public object MGLoggerJni : ILoggerProtocol {
     private external fun mglogger_flush()
     private external fun nativeStartLogcatCollector(blackList: Array<String>)
     private external fun nativeHookLogs()
+    private external fun nativeCollectLogByLoggerList()
 
     public fun startLogcatCollector(blackList: Array<String>) {
         try {
@@ -77,6 +78,14 @@ public object MGLoggerJni : ILoggerProtocol {
     public fun hookLogs() {
         try {
             nativeHookLogs()
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+        }
+    }
+
+    public fun collectLogByLoggerList() {
+        try {
+            nativeCollectLogByLoggerList()
         } catch (e: UnsatisfiedLinkError) {
             e.printStackTrace()
         }


### PR DESCRIPTION
## Summary
- extend Logreader with `collect_log_by_loggerlist` using `android_logger_list_read`
- expose new JNI bindings and Kotlin helpers
- allow `getSystemLogs` mode 3 to trigger the new collection method

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b74f9a00c83298b67b6f336358ae9