### PR TITLE
Implement async logging queue

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_queue.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_queue.cpp
@@ -22,40 +22,46 @@ void logger_queue::stop() {
         std::unique_lock<std::mutex> lock(m_mutex);
         m_running = false;
     }
-    m_cv.notify_all();
+    m_cv_not_empty.notify_all();
+    m_cv_not_full.notify_all();
     if (m_worker.joinable()) {
         m_worker.join();
     }
 }
 
-int logger_queue::dispatch(const std::function<int()> &task) {
+int logger_queue::dispatch(const std::function<void()> &task) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (!m_running) {
+        return -1;
+    }
+    while (m_queue.size() >= m_capacity && m_running) {
+        m_cv_not_full.wait(lock);
+    }
+    if (!m_running) {
+        return -1;
+    }
+    m_queue.emplace(task);
+    m_cv_not_empty.notify_one();
+    return 0;
+}
+
+int logger_queue::dispatch_sync(const std::function<int()> &task) {
     auto p = std::make_shared<std::promise<int>>();
     auto f = p->get_future();
-    {
-        std::unique_lock<std::mutex> lock(m_mutex);
-        if (!m_running) {
-            return -1;
-        }
-        m_queue.emplace([task, p]() { p->set_value(task()); });
+    int ret = dispatch([task, p]() { p->set_value(task()); });
+    if (ret != 0) {
+        return ret;
     }
-    m_cv.notify_one();
     return f.get();
 }
 
-void logger_queue::dispatch_void(const std::function<void()> &task) {
+void logger_queue::dispatch_sync_void(const std::function<void()> &task) {
     auto p = std::make_shared<std::promise<void>>();
     auto f = p->get_future();
-    {
-        std::unique_lock<std::mutex> lock(m_mutex);
-        if (!m_running) {
-            return;
-        }
-        m_queue.emplace([task, p]() {
-            task();
-            p->set_value();
-        });
-    }
-    m_cv.notify_one();
+    dispatch([task, p]() {
+        task();
+        p->set_value();
+    });
     f.get();
 }
 
@@ -64,12 +70,13 @@ void logger_queue::loop() {
         task_t task;
         {
             std::unique_lock<std::mutex> lock(m_mutex);
-            m_cv.wait(lock, [this]() { return !m_queue.empty() || !m_running; });
+            m_cv_not_empty.wait(lock, [this]() { return !m_queue.empty() || !m_running; });
             if (!m_running && m_queue.empty()) {
                 break;
             }
             task = std::move(m_queue.front());
             m_queue.pop();
+            m_cv_not_full.notify_one();
         }
         task();
     }

--- a/mglogger/src/main/cpp/mglogger/mg/logger_queue.h
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_queue.h
@@ -21,15 +21,17 @@ public:
     logger_queue();
     ~logger_queue();
 
-    // Schedule a task returning an int result. The task will be executed
-    // on the internal worker thread and the result is returned to the caller.
-    // When the queue has been stopped, this returns -1 without executing
-    // the task.
-    int dispatch(const std::function<int()> &task);
+    // Asynchronously enqueue a task. Returns 0 on success or -1 if the queue
+    // has been stopped.
+    int dispatch(const std::function<void()> &task);
 
-    // Schedule a void task. The call blocks until the task has been
-    // executed. When the queue has been stopped the task is ignored.
-    void dispatch_void(const std::function<void()> &task);
+    // Schedule a task and wait for its result. This is used for operations that
+    // require a return value.
+    int dispatch_sync(const std::function<int()> &task);
+
+    // Schedule a void task and block until completion.
+    void dispatch_sync_void(const std::function<void()> &task);
+
     void stop();
 
 private:
@@ -38,9 +40,11 @@ private:
 
     std::queue<task_t> m_queue;
     std::mutex m_mutex;
-    std::condition_variable m_cv;
+    std::condition_variable m_cv_not_empty;
+    std::condition_variable m_cv_not_full;
     bool m_running{true};
     std::thread m_worker;
+    const size_t m_capacity = 1024;
 };
 
 #endif //MGLOGGER_LOGGER_QUEUE_H

--- a/mglogger/src/main/cpp/mglogger/mg/mg_logger.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/mg_logger.cpp
@@ -22,31 +22,32 @@ mg_logger::~mg_logger() {
 
 int mg_logger::init(const char* cache_path, const char* dir_path, int max_file,
                     const char* key16, const char* iv16) {
-    return m_queue->dispatch([=]() {
+    return m_queue->dispatch_sync([=]() {
         return clogan_init(cache_path, dir_path, max_file, key16, iv16);
     });
 }
 
 int mg_logger::open(const char* file_name) {
-    return m_queue->dispatch([=]() {
+    return m_queue->dispatch_sync([=]() {
         return clogan_open(file_name);
     });
 }
 
 int mg_logger::write(int flag, const char* log, long long local_time,
                      const char* thread_name, long long thread_id, int is_main) {
-    return m_queue->dispatch([=]() {
-        return clogan_write(flag, (char*)log, local_time, (char*)thread_name,
-                            thread_id, is_main);
+    int ret = m_queue->dispatch([=]() {
+        clogan_write(flag, (char*)log, local_time, (char*)thread_name,
+                     thread_id, is_main);
     });
+    return ret;
 }
 
 int mg_logger::flush() {
-    return m_queue->dispatch([=]() { return clogan_flush(); });
+    return m_queue->dispatch_sync([=]() { return clogan_flush(); });
 }
 
 void mg_logger::debug(int debug) {
-    m_queue->dispatch_void([=]() { clogan_debug(debug); });
+    m_queue->dispatch([=]() { clogan_debug(debug); });
 }
 
 void mg_logger::stop() {


### PR DESCRIPTION
## Summary
- refactor logger queue into asynchronous producer/consumer model
- update mg_logger to use new async queue

## Testing
- `./gradlew tasks --all` *(fails: unable to tunnel through proxy)*
- `./gradlew -q help` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6874a658a108832981143613f554097a