### PR TITLE
Add JNI event listener bridge

### DIFF
--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCE_LOGGER
         mglogger/mg/logger_queue.cpp
         mglogger/mg/message_queue.cpp
         mglogger/mg/logger_core.cpp
+        mglogger/mg/logger_listener.cpp
 )
 
 set(SRC_J4A

--- a/mglogger/src/main/cpp/jni/logger_jni.cpp
+++ b/mglogger/src/main/cpp/jni/logger_jni.cpp
@@ -4,6 +4,8 @@
 
 #include "jni.h"
 #include "logger_core.h"
+#include "logger_listener.h"
+#include "logger_common.h"
 
 static JavaVM *g_vm = nullptr;
 
@@ -26,6 +28,8 @@ namespace MGLogger {
         const char *encrypt_key16_ = env->GetStringUTFChars(encrypt_key16, 0);
         const char *encrypt_iv16_ = env->GetStringUTFChars(encrypt_iv16, 0);
 
+        env->GetJavaVM(&g_vm);
+
         logger = std::make_shared<MGLogger>();
         int code = logger->init(cache_path_,
                                 dir_path_,
@@ -33,6 +37,9 @@ namespace MGLogger {
                                 max_file,
                                 encrypt_key16_,
                                 encrypt_iv16_);
+        if (code == MG_OK) {
+            logger->SetOnEventListener(createJniEventListener(env, thiz));
+        }
 
         env->ReleaseStringUTFChars(dir_path, dir_path_);
         env->ReleaseStringUTFChars(cache_path, cache_path_);

--- a/mglogger/src/main/cpp/mglogger/mg/logger_listener.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_listener.cpp
@@ -1,0 +1,37 @@
+#include "logger_listener.h"
+#include "external/j4a/logger/OnEventListener.h"
+#include "external/sdl/sdl_android_jni.h"
+
+namespace MGLogger {
+
+class JniEventListener : public OnEventListener {
+public:
+    JniEventListener(JNIEnv *env, jobject thiz) {
+        m_thiz = J4A_NewGlobalRef__catchAll(env, thiz);
+    }
+
+    ~JniEventListener() override {
+        if (!m_thiz) return;
+        JNIEnv *env = nullptr;
+        if (SDL_JNI_SetupThreadEnv(&env) == JNI_OK) {
+            J4A_DeleteGlobalRef__p(env, &m_thiz);
+        }
+    }
+
+    void onEvent(int what, const char *cmd) override {
+        if (!m_thiz) return;
+        JNIEnv *env = nullptr;
+        if (SDL_JNI_SetupThreadEnv(&env) != JNI_OK) return;
+        J4AC_com_mgtv_logger_kt_log_MGLoggerJni__onLoggerStatus__withCString__catchAll(env, m_thiz, what, cmd ? cmd : "");
+    }
+
+private:
+    jobject m_thiz{nullptr};
+};
+
+std::shared_ptr<OnEventListener> createJniEventListener(JNIEnv *env, jobject thiz) {
+    return std::make_shared<JniEventListener>(env, thiz);
+}
+
+} // namespace MGLogger
+

--- a/mglogger/src/main/cpp/mglogger/mg/logger_listener.h
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_listener.h
@@ -5,12 +5,17 @@
 #ifndef MGLOGGER_LOGGER_LISTENER_H
 #define MGLOGGER_LOGGER_LISTENER_H
 
+#include <jni.h>
+#include <memory>
+
 namespace MGLogger {
 
     class OnEventListener {
     public:
         virtual void onEvent(int what, const char *cmd) = 0;
     };
+
+    std::shared_ptr<OnEventListener> createJniEventListener(JNIEnv *env, jobject thiz);
 }
 
 #endif //MGLOGGER_LOGGER_LISTENER_H


### PR DESCRIPTION
## Summary
- implement `JniEventListener` to forward native events to Kotlin
- expose factory in `logger_listener.h`
- register listener during `LoggerInit`
- include new source in native build

## Testing
- `./gradlew tasks --all` *(fails: unable to access network)*

------
https://chatgpt.com/codex/tasks/task_e_688080d1129c8329b428ff55d17dcf6d