### PR TITLE
Fix JNI callback visibility

### DIFF
--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -173,11 +173,14 @@ public object MGLoggerJni : ILoggerProtocol {
     }
 
     @Keep
-    internal fun onLoggerStatus(code: Int,cmd: String) {
+    @JvmStatic
+    public fun onLoggerStatus(code: Int, cmd: String) {
         loggerStatusCode(cmd, code)
     }
 
-    internal fun onLogcatCollectorFail() {
+    @Keep
+    @JvmStatic
+    public fun onLogcatCollectorFail() {
         loggerStatusCode(
             MGLoggerStatus.MGLOGGER_LOGCAT_COLLECTOR_STATUS,
             MGLoggerStatus.MGLOGGER_LOGCAT_COLLECTOR_FAIL


### PR DESCRIPTION
## Summary
- expose `onLoggerStatus` and `onLogcatCollectorFail` as public static functions

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6880878db7208329a501330edd0bc71e