### PR TITLE
feat: support initialization blacklist

### DIFF
--- a/mglogger/src/main/cpp/jni/logger_jni.cpp
+++ b/mglogger/src/main/cpp/jni/logger_jni.cpp
@@ -103,5 +103,27 @@ namespace MGLogger {
     Java_com_mgtv_logger_kt_log_MGLoggerJni_LoggerFlush(JNIEnv *env, jobject thiz) {
         logger->flush();
     }
+
+    extern "C"
+    JNIEXPORT void JNICALL
+    Java_com_mgtv_logger_kt_log_MGLoggerJni_LoggerSetBlackList(JNIEnv *env,
+                                                               jobject thiz,
+                                                               jobjectArray list) {
+        if (logger == nullptr) {
+            return;
+        }
+        std::list<std::string> vec;
+        if (list != nullptr) {
+            jsize len = env->GetArrayLength(list);
+            for (jsize i = 0; i < len; ++i) {
+                jstring item = (jstring) env->GetObjectArrayElement(list, i);
+                const char *c_str = env->GetStringUTFChars(item, 0);
+                vec.emplace_back(c_str);
+                env->ReleaseStringUTFChars(item, c_str);
+                env->DeleteLocalRef(item);
+            }
+        }
+        logger->setBlackList(vec);
+    }
 }
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/i/ILoggerProtocol.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/i/ILoggerProtocol.kt
@@ -66,4 +66,10 @@ public interface ILoggerProtocol {
      * @param listener The listener to be notified of logger status changes.
      */
     public fun setOnLoggerStatus(listener: ILoggerStatus)
+
+    /**
+     * Update logger blacklist.
+     * @param blackList Tags that should be ignored when capturing logcat.
+     */
+    public fun setBlackList(blackList: List<String>)
 }

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/LoggerActor.kt
@@ -44,6 +44,9 @@ internal class LoggerActor(
             }
         })
         logger_init(cfg.cachePath, cfg.logDir,cfg.logCacheS, cfg.maxFile.toInt(), cfg.key16, cfg.iv16)
+        if (cfg.logcatBlackList.isNotEmpty()) {
+            setBlackList(cfg.logcatBlackList)
+        }
 //        it.logger_debug(Logger.sDebug)
     }
 

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLogger.kt
@@ -21,6 +21,7 @@ public object MGLogger {
             {
                 putCachePath(config.cachePath)
                 putLogDir(config.logDir)
+                putLogcatBlackList(config.logcatBlackList)
 //                        putKeepDays(config.keepDays)
 //                        putMaxFile(config.maxFile)
 //                        putMinSdCard(config.minSdCard)

--- a/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
+++ b/mglogger/src/main/java/com/mgtv/logger/kt/log/MGLoggerJni.kt
@@ -65,6 +65,7 @@ public class MGLoggerJni : ILoggerProtocol {
     ): Int
 
     private external fun LoggerFlush()
+    private external fun LoggerSetBlackList(list: Array<String>)
 
     // ----------------------------
     // LoganProtocolHandler impl
@@ -132,6 +133,15 @@ public class MGLoggerJni : ILoggerProtocol {
         if (!isLoganOpen || !isMGLoggerOk) return
         try {
             LoggerFlush()
+        } catch (e: UnsatisfiedLinkError) {
+            e.printStackTrace()
+        }
+    }
+
+    public override fun setBlackList(blackList: List<String>) {
+        if (!isMGLoggerOk) return
+        try {
+            LoggerSetBlackList(blackList.toTypedArray())
         } catch (e: UnsatisfiedLinkError) {
             e.printStackTrace()
         }


### PR DESCRIPTION
## Summary
- add blacklist setter to `ILoggerProtocol`
- expose blacklist API in `MGLoggerJni`
- apply blacklist during logger initialization
- pass blacklist config from `MGLogger.init`
- add JNI bridge for `setBlackList`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6880963418048329b0aa40a5601b3c1e