### PR TITLE
Fix truncated error logs

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_common.h
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_common.h
@@ -36,7 +36,7 @@
 #define LEVEL_VERBOSE 5
 #define LEVEL_UNKNOWN -1
 
-#define LOG_MAX_LENGTH 1024 // 日志最大长度
+#define LOG_MAX_LENGTH 2048 // 日志最大长度，保持与 MAX_MSG_LENGTH 一致
 #define ANDROID_API_LEVEL 19 // Android API level
 #define LOG_EXTERNAL_SIZE (1 * 1024 * 1024) // 扩展大小 1MB
 

--- a/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
@@ -173,7 +173,7 @@ void LoggerFork::parseThreadTimeLine(const char *line, MGLog *out) {
     char msgBuf[MAX_MSG_LENGTH] = {0};
     // 使用 sscanf 解析日志行
     int matched = sscanf(line,
-                         "%15s %15s %d %lld %c %63[^:]: %1025[^\n]",
+                         "%15s %15s %d %lld %c %63[^:]: %2049[^\n]",
                          date, time, &pid, &tid, &level, tagBuf, msgBuf);
     if (matched >= 6) {
         out->tid = tid;

--- a/mglogger/src/main/cpp/mglogger/mg/logger_hook.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_hook.cpp
@@ -223,7 +223,7 @@ int LoggerHook::hookLogPrint(int prio, const char *tag, const char *fmt, ...) {
 
 #if OPEN_VPRINT
 int LoggerHook::hookLogVPrint(int prio, const char *tag, const char *fmt, va_list ap) {
-        char msgBuf[1024];
+        char msgBuf[LOG_MAX_LENGTH];
         vsnprintf(msgBuf, sizeof(msgBuf), fmt, ap);
         MGLog log{};
         log.tid = my_tid();
@@ -328,13 +328,13 @@ int LoggerHook::hookLogBufWrite(int bufID, int prio, const char *tag, const char
 #if OPEN_ASSERT
 void LoggerHook::hookLogAssert(const char *cond, const char *tag, const char *fmt, ...) {
         // 格式化断言日志消息
-        char msgBuf[1024];
+        char msgBuf[LOG_MAX_LENGTH];
         va_list args, args_copy;
         va_start(args, fmt);
         va_copy(args_copy, args);
         vsnprintf(msgBuf, sizeof(msgBuf), fmt, args);
         va_end(args);
-        char fullMsg[1280];
+        char fullMsg[LOG_MAX_LENGTH + 256];
         snprintf(fullMsg, sizeof(fullMsg), "[ASSERT:%s] %s",
                  cond ? cond : "null", msgBuf);
         MGLog log{};


### PR DESCRIPTION
## Summary
- enlarge `LOG_MAX_LENGTH` to match `MAX_MSG_LENGTH`
- use the new constant in hook functions
- update fork parser pattern for larger messages

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*
- `./gradlew -q tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68824fe524ac8329b94a863ec279f745