### PR TITLE
Add log level parsing in LoggerFork

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
@@ -189,11 +189,35 @@ void LoggerFork::parseThreadTimeLine(const char *line, MGLog *out) {
         snprintf(finalMsg, sizeof(finalMsg), "%c %s", level, msgBuf);
         strncpy(out->msg, finalMsg, MAX_MSG_LENGTH - 1);
         out->msg[MAX_MSG_LENGTH - 1] = '\0';
+        switch (level) {
+            case LOG_DEBUG:
+                out->level = LEVEL_DEBUG;
+                break;
+            case LOG_INFO:
+                out->level = LEVEL_INFO;
+                break;
+            case LOG_WARN:
+                out->level = LEVEL_WARN;
+                break;
+            case LOG_ERROR:
+                out->level = LEVEL_ERROR;
+                break;
+            case LOG_FATAL:
+                out->level = LEVEL_FATAL;
+                break;
+            case LOG_VERBOSE:
+                out->level = LEVEL_VERBOSE;
+                break;
+            default:
+                out->level = LEVEL_UNKNOWN;
+                break;
+        }
     } else {
         out->tid = 0;
         out->tag[0] = '\0';
         strncpy(out->msg, line, MAX_MSG_LENGTH - 1);
         out->msg[MAX_MSG_LENGTH - 1] = '\0';
+        out->level = LEVEL_UNKNOWN;
     }
     out->ts = utils::LoggerUtils::nowMs();
 }


### PR DESCRIPTION
## Summary
- support log level in `parseThreadTimeLine`

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6882da39b870832982e6b2e29a55f2f4