### PR TITLE
Add copy task for armeabi lib

### DIFF
--- a/mglogger/build.gradle
+++ b/mglogger/build.gradle
@@ -57,3 +57,22 @@ android {
 dependencies {
     implementation("androidx.annotation:annotation:1.3.0")
 }
+
+afterEvaluate {
+    android.libraryVariants.all { variant ->
+        def capitalized = variant.name.capitalize()
+        def srcLib = file("$buildDir/intermediates/cmake/${variant.name}/obj/armeabi-v7a/libmglogger.so")
+        def destDir = file("$buildDir/intermediates/cmake/${variant.name}/obj/armeabi")
+
+        def copyTask = tasks.register("copy${capitalized}ArmeabiLib", Copy) {
+            from(srcLib)
+            into(destDir)
+            doFirst { destDir.mkdirs() }
+            onlyIf { srcLib.exists() }
+        }
+
+        tasks.named("externalNativeBuild${capitalized}").configure {
+            finalizedBy(copyTask)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add afterEvaluate block to copy `libmglogger.so` from `armeabi-v7a` output to `armeabi` during build

## Testing
- `./gradlew :mglogger:tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6889f07f6e9c8329995002a479c48ac6