### PR TITLE
Fix poll hangup handling in LoggerFork

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
@@ -180,6 +180,10 @@ int LoggerFork::handleForkLogs() {
             MGLog mgLog{};
             parseThreadTimeLine(buffer, &mgLog);
             writeLog(&mgLog, LOG_SRC_FORK);
+        } else if (pollRet > 0 && (pfd.revents & (POLLHUP | POLLERR))) {
+            ALOGE("LoggerFork::handleForkLogs - poll hangup or error");
+            sendMessage(MG_LOGGER_STATUS_FORK_EXITED, "logcat hangup");
+            break;
         } else if (pollRet == 0) { // timeout
             if (!firstDataRead) {
                 ALOGE("LoggerFork::handleForkLogs - logcat no output, timeout");


### PR DESCRIPTION
## Summary
- handle POLLHUP or POLLERR when polling logcat output

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688c842d31808329a602f4a467cd5b34