### PR TITLE
Fix missing log caching after fork timeout

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_core.h
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_core.h
@@ -67,6 +67,17 @@ namespace MGLogger {
 
         SDL_Thread *createMessageTh();
 
+        /**
+         * Stop worker and message threads
+         */
+        void stopThreads();
+
+        /**
+         * Start worker and message threads
+         * @return true if both threads created successfully
+         */
+        bool startThreads();
+
         void handleMessage(const std::shared_ptr<MGMessage> &msg);
 
         int write(MGLog *log);


### PR DESCRIPTION
## Summary
- restart worker and message threads when switching to Hook mode after fork timeout
- encapsulate thread management into helper functions

## Testing
- `./gradlew testClasses` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688c890957088329b799b15d197059f4