### PR TITLE
fix: propagate native logger events to Java

### DIFF
--- a/mglogger/src/main/cpp/jni/logger_jni.cpp
+++ b/mglogger/src/main/cpp/jni/logger_jni.cpp
@@ -16,7 +16,7 @@ namespace MGLogger {
     extern "C"
     JNIEXPORT jint JNICALL
     Java_com_mgtv_logger_log_LoggerNativeBridge_initLogger(JNIEnv *env,
-                                                           jclass clazz,
+                                                           jobject thiz,
                                                            jstring cache_path,
                                                            jstring dir_path,
                                                            jint log_cache_selector,
@@ -41,7 +41,7 @@ namespace MGLogger {
                                 encrypt_key16_,
                                 encrypt_iv16_);
         if (code == MG_OK) {
-            logger->SetOnEventListener(createJniEventListener(env, clazz));
+            logger->SetOnEventListener(createJniEventListener(env, thiz));
         }
 
         env->ReleaseStringUTFChars(dir_path, dir_path_);

--- a/mglogger/src/main/java/com/mgtv/logger/log/LoggerNativeBridge.java
+++ b/mglogger/src/main/java/com/mgtv/logger/log/LoggerNativeBridge.java
@@ -55,13 +55,13 @@ public class LoggerNativeBridge implements ILogger {
         return isMGLoggerOk;
     }
 
-    public static native int initLogger( String cachePath,
-                                          String dirPath,
-                                          int    logCacheSelector,
-                                          int    maxFile,
-                                          int    maxSdCardSize,
-                                          String encryptKey16,
-                                          String encryptIv16);
+    private native int initLogger( String cachePath,
+                                   String dirPath,
+                                   int    logCacheSelector,
+                                   int    maxFile,
+                                   int    maxSdCardSize,
+                                   String encryptKey16,
+                                   String encryptIv16);
 
 
     private native int  LoggerOpen(String fileName);


### PR DESCRIPTION
## Summary
- ensure native `MGLogger` events invoke Java `onLoggerStatus`

## Testing
- `./gradlew :mglogger:test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_689011324da88329b455350edd135979