### PR TITLE
fix: avoid thread hang when switching to hook mode

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_fork.cpp
@@ -307,5 +307,10 @@ void LoggerFork::stop() {
         waitpid(s_child_pid, nullptr, 0);
         s_child_pid = -1;
     }
+    if (forkThread) {
+        SDL_WaitThread(forkThread, nullptr);
+        forkThread = nullptr;
+    }
+    BaseLogger::stop();
 }
 


### PR DESCRIPTION
## 变更概要
- stop fork logger before switch to hook mode
- abort fork queues and join fork thread

## 关联 Issue/任务单
- N/A

------
https://chatgpt.com/codex/tasks/task_e_689018782aac8329bd58ff95419bf4fe