### PR TITLE
fix(mglogger): avoid self-join deadlock when switching to hook mode

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_core.h
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_core.h
@@ -50,6 +50,9 @@ namespace MGLogger {
 
         void stop();
 
+        // 切换到 Hook 模式
+        int switchToHookMode();
+
         void setBlackList(const std::list<std::string> &blackList);
 
         static int threadFunc(void *arg);
@@ -72,6 +75,9 @@ namespace MGLogger {
         int write(MGLog *log);
 
         int reWrite(MGLog *log);
+
+        // 停止工作线程和消息线程
+        void stopThreads();
 
 
     private:


### PR DESCRIPTION
## Summary
- add `switchToHookMode` to rebuild logger using hook strategy
- guard `stopThreads` against joining the current thread

## Testing
- `./gradlew :mglogger:build` *(fails: Could not resolve com.android.tools.build:gradle:4.1.3)*

------
https://chatgpt.com/codex/tasks/task_e_68901e979e888329a3ab95e9c2cba9fb