### PR TITLE
fix(native): avoid debug logs in release

### DIFF
--- a/mglogger/src/main/cpp/external/sdl/sdl_log_config.h
+++ b/mglogger/src/main/cpp/external/sdl/sdl_log_config.h
@@ -16,5 +16,9 @@
 #define LOG_LEVEL_ERROR   (4)
 #define LOG_LEVEL_FATAL   (5)
 
+#ifdef NDEBUG
+#define MGLOGGER_LOG_LEVEL (LOG_LEVEL_INFO)
+#else
 #define MGLOGGER_LOG_LEVEL (LOG_LEVEL_DEBUG)
+#endif
 #endif //MGLOGGER_SDL_LOG_CONFIG_H


### PR DESCRIPTION
## Summary
- conditionally raise log level when `NDEBUG` is defined to suppress debug logs in release builds

## Testing
- `./gradlew :mglogger:assembleRelease` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68905191f9d8832988ed02149eed8315