### PR TITLE
fix(build): enable release signing and optional mglogger aar

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'com.android.application'
 
+def useLocalMgloggerAar = rootProject.ext.useLocalMgloggerAar
+
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -25,6 +33,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {
@@ -36,7 +45,11 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation project(':mglogger')
+    if (useLocalMgloggerAar) {
+        implementation(name: 'mglogger_1.0.0', ext: 'aar')
+    } else {
+        implementation project(':mglogger')
+    }
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core:1.0.2'
     implementation 'androidx.lifecycle:lifecycle-common:2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ ext {
     targetSdkVersion = 33 // <-- 从 28 更新
     compileSdkVersion = 33 // <-- 从 28 更新
     buildToolsVersion = '33.0.2' // <-- 建议更新，或移除让 AGP 自动选择
+
+    // Toggle to use mglogger AAR in app module instead of project dependency
+    useLocalMgloggerAar = false
 }
 
 tasks.register('clean', Delete) {


### PR DESCRIPTION
## Summary
- add switch to choose mglogger AAR or project dependency
- sign release build with configured keystore

## Testing
- `./gradlew :app:assembleRelease` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_689084faba308329aeb8148cb173aa02