### PR TITLE
fix(build): optimize release native build

### DIFF
--- a/mglogger/build.gradle
+++ b/mglogger/build.gradle
@@ -19,6 +19,13 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            externalNativeBuild {
+                cmake {
+                    cppFlags "-Os -ffunction-sections -fdata-sections -fvisibility=hidden -flto"
+                    ldFlags "-Wl,--gc-sections"
+                    arguments "-DCMAKE_BUILD_TYPE=Release"
+                }
+            }
         }
 
         debug {

--- a/mglogger/src/main/cpp/CMakeLists.txt
+++ b/mglogger/src/main/cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required(VERSION 3.8.0)
 # build script scope).
 project("mglogger")
 
-#set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE Release)
 
 
 # Set C++ standard


### PR DESCRIPTION
## Summary
- add optimization and linker flags for mglogger's release native build
- set CMake to build in Release mode

## Issue
- n/a

------
https://chatgpt.com/codex/tasks/task_e_6890d2a652cc8329bd1916eeefac2a11