### PR TITLE
fix(build): strip armeabi native lib

### DIFF
--- a/mglogger/build.gradle
+++ b/mglogger/build.gradle
@@ -85,11 +85,12 @@ afterEvaluate {
 
         if (variant.buildType.name == "release") {
             def extraStripTask = tasks.register("extraStrip${capitalized}") {
+                dependsOn(copyTask)
                 doLast {
                     def osName = org.gradle.internal.os.OperatingSystem.current()
                     def host = osName.isMacOsX() ? "darwin-x86_64" : (osName.isWindows() ? "windows-x86_64" : "linux-x86_64")
                     def llvmStrip = "${android.ndkDirectory}/toolchains/llvm/prebuilt/${host}/bin/llvm-strip"
-                    ["armeabi-v7a", "arm64-v8a"].each { abi ->
+                    ["armeabi", "armeabi-v7a", "arm64-v8a"].each { abi ->
                         def soFile = file("$buildDir/intermediates/cmake/${variant.name}/obj/${abi}/libmglogger.so")
                         if (soFile.exists()) {
                             project.exec { commandLine llvmStrip, "--strip-all", soFile }


### PR DESCRIPTION
## Summary
- strip the copied armeabi `.so` to keep file size small

## Testing
- `./gradlew :mglogger:assembleRelease` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6891b53a47f88329baf12c4bcddbff5a