### PR TITLE
fix(native): unlock mutex after exporting logs

### DIFF
--- a/mglogger/src/main/cpp/mglogger/mg/logger_core.cpp
+++ b/mglogger/src/main/cpp/mglogger/mg/logger_core.cpp
@@ -649,8 +649,9 @@ namespace MGLogger {
         ALOGI("MGLogger::exportLogs - Exporting logs to %s", file_name ? file_name : "null");
         SDL_LockMutex(m_mutex);
         char *logs_path = const_cast<char *>(mCacheFilePath.c_str());
-        return utils::LoggerUtils::mergeCompressedFiles(logs_path, file_name);
+        int code = utils::LoggerUtils::mergeCompressedFiles(logs_path, file_name);
         SDL_UnlockMutex(m_mutex);
+        return code;
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure native exportLogs unlocks mutex

## Testing
- `./gradlew :mglogger:assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_689997e9d93083298d8697217a9c256c