### PR TITLE
chore(build): upgrade Gradle and CMake

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    namespace "com.lt.mglogger"
+    compileSdk rootProject.ext.compileSdk
 
     signingConfigs {
         release {
@@ -22,8 +23,8 @@ android {
 
     defaultConfig {
         applicationId "com.mgtv.mglogger"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdk
+        targetSdk rootProject.ext.targetSdk
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.0.2'
 //        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 //        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
@@ -29,11 +29,11 @@ allprojects {
 ext {
 
     // SDK And Tools
-    minSdkVersion = 14 // <-- 保持 16
+    minSdk = 14 // <-- 保持 16
     // 更新 target 和 compile SDK 版本
-    targetSdkVersion = 33 // <-- 从 28 更新
-    compileSdkVersion = 33 // <-- 从 28 更新
-    buildToolsVersion = '33.0.2' // <-- 建议更新，或移除让 AGP 自动选择
+    targetSdk = 34 // <-- 从 28 更新
+    compileSdk = 34 // <-- 从 28 更新
+    buildToolsVersion = '34.0.0' // <-- 建议更新，或移除让 AGP 自动选择
 
     useLocalMgloggerAar = false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip

--- a/ljjlogger/build.gradle
+++ b/ljjlogger/build.gradle
@@ -1,10 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    namespace "com.lt.logger"
+    compileSdk rootProject.ext.compileSdk
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdk rootProject.ext.minSdk
+        targetSdk rootProject.ext.targetSdk
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
         externalNativeBuild {
@@ -42,7 +43,7 @@ android {
     externalNativeBuild {
         cmake {
             path "src/main/cpp/CMakeLists.txt"
-            version "3.10.2"
+            version "3.22.1"
         }
     }
     compileOptions {


### PR DESCRIPTION
## Summary
- upgrade Gradle wrapper to 8.0 and Android Gradle Plugin to 8.0.2
- bump compile/target SDK to 34 with min SDK 14 and add required namespaces
- update CMake toolchain to version 3.22.1

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" when downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68a48da12ce88329b5b33e498afc8d59